### PR TITLE
Make Litecoin Core and base image updatable by Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,30 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "docker:enableMajor",
+    "mergeConfidence:all-badges",
+    ":disableRateLimiting",
+    ":semanticCommits"
+  ],
+  "rebaseWhen": "conflicted",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)(\\sARG .*?_CHECKSUM=(?<currentDigest>.*))?\\s",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_BRANCH=(?<currentValue>.*)(\\sARG .*?_COMMIT_HASH=(?<currentDigest>.*))?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["litecoin-project/litecoin"],
+      "extractVersion": "^v(?<version>.*)$"
+    }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest available Ubuntu image as build stage
-FROM ubuntu:latest AS builder
+FROM ubuntu:26.04 AS builder
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
@@ -13,10 +13,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 # Set variables necessary for download and verification of bitcoind
 ARG TARGETARCH
 ARG ARCH
-ARG VERSION=0.21.5.5
+# renovate: datasource=github-releases depName=litecoin-project/litecoin versioning=loose
+ARG LITECOIN_VERSION=0.21.5.5
 ARG LITECOIN_CORE_SIGNATURE=D35621D53A1CC6A3456758D03620E9D387E55666
 ENV LITECOIN_DATA=/litecoin/.litecoin
-ENV PATH=/opt/litecoin-${VERSION}/bin:$PATH
+ENV PATH=/opt/litecoin-${LITECOIN_VERSION}/bin:$PATH
 
 RUN case ${TARGETARCH:-amd64} in \
     "arm64") ARCH="aarch64-linux-gnu";; \
@@ -24,17 +25,17 @@ RUN case ${TARGETARCH:-amd64} in \
     *) echo "Dockerfile does not support this platform"; exit 1 ;; \
     esac \
     && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys ${LITECOIN_CORE_SIGNATURE} \
-    && wget -q --show-progress --progress=dot:giga https://download.litecoin.org/litecoin-${VERSION}/linux/litecoin-${VERSION}-${ARCH}.tar.gz \
-            https://download.litecoin.org/litecoin-${VERSION}/SHA256SUMS.asc \
+    && wget -q --show-progress --progress=dot:giga https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/linux/litecoin-${LITECOIN_VERSION}-${ARCH}.tar.gz \
+            https://download.litecoin.org/litecoin-${LITECOIN_VERSION}/SHA256SUMS.asc \
     && gpg --verify SHA256SUMS.asc \
-    && grep " litecoin-${VERSION}-${ARCH}.tar.gz" SHA256SUMS.asc | sha256sum -c - \
+    && grep " litecoin-${LITECOIN_VERSION}-${ARCH}.tar.gz" SHA256SUMS.asc | sha256sum -c - \
     && tar -xzf *.tar.gz -C /opt \
-    && ln -sv litecoin-${VERSION} /opt/litecoin \
+    && ln -sv litecoin-${LITECOIN_VERSION} /opt/litecoin \
     && rm *.tar.gz *.asc \
-    && rm -rf /opt/litecoin-${VERSION}/bin/litecoin-qt
+    && rm -rf /opt/litecoin-${LITECOIN_VERSION}/bin/litecoin-qt
 
 # Use latest Ubuntu image as base for main image
-FROM ubuntu:latest AS final
+FROM ubuntu:26.04 AS final
 
 WORKDIR /litecoin
 


### PR DESCRIPTION
### Summary
Follow-up to #57: the actions are pinned and maintained, but the two most important dependencies in this repo were invisible to Renovate.

### Changes
- **`ARG VERSION` → `ARG LITECOIN_VERSION`** with a `# renovate:` annotation (`github-releases` / `litecoin-project/litecoin`, `versioning=loose` for the 4-segment scheme). The old bare `VERSION` name had no annotation and didn't match the shared `.*_VERSION` regex manager, so Litecoin Core releases were never picked up. The release workflow's `awk -F '=' '/VERSION=/'` extraction matches the new name unchanged (verified: yields `0.21.5.5`).
- **`FROM ubuntu:latest` → `FROM ubuntu:26.04`** (both stages). `latest` is exactly what 26.04 resolves to today, so no build change — but a floating tag gives Renovate's docker manager nothing to version-track, and now Ubuntu bumps arrive as reviewable PRs.
- **`renovate.json` expanded** to the shared config used by simple-monerod-docker / p2pool-docker (semantic commits, docker major updates, merge-confidence badges, custom Dockerfile ARG managers), plus an `extractVersion` rule stripping the `v` prefix from upstream tags (`v0.21.5.5` → `0.21.5.5`) so the written value keeps matching the download.litecoin.org URL format.

### Verification
- Custom-manager regex tested against the new Dockerfile: captures `depName=litecoin-project/litecoin`, `currentValue=0.21.5.5`.
- `renovate.json` parses as valid JSON.
- ⚠️ Note for local builds: the build arg is now `--build-arg LITECOIN_VERSION=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)